### PR TITLE
Add DTR and RTS support via web serial

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,9 +34,9 @@
       <ul class="navbar-nav mr-auto"></ul>
       <div class="form-inline mt-2 mt-md-0">
         <label class="form-check-label" style="color: white;">
-          <input class="form-check-input" type="checkbox" id="dtr-control"> DTR </label>
+          <input class="form-check-input" type="checkbox" disabled id="dtr-control"> DTR </label>
         <label class="form-check-label" style="padding:10px; color: white;">
-          <input class="form-check-input" type="checkbox" id="rts-control"> RTS </label>
+          <input class="form-check-input" type="checkbox" disabled id="rts-control"> RTS </label>
         <button class="btn btn-outline options-btn" data-toggle="modal" data-target="#options-modal"
           style="margin-right: 5px;"> Options </button>
         <button class="btn btn-outline-success my-2 my-sm-0" id="connect">Connect</button>


### PR DESCRIPTION
### How to test
- [ ] connect sjtwo to computer
- [ ] navigate to `file:///path/to/web-serial/index.html`\
- [ ] Hit `Connect`
- [ ] ensure correct port is shown
- [ ] after selecting port, ensure text shows up in terminal
![image](https://user-images.githubusercontent.com/36345325/178156881-022ba325-ed8e-4e36-8684-4e3539b25caf.png)

- [ ] ensure after connecting dtr and rts checkboxes become enabled
- [ ] verify correct functionality, i.e. toggling dtr on/off resets the device and it runs from the start again
